### PR TITLE
[#7, #71] Automatically toggle defeated status when damaging or healing

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -189,7 +189,7 @@ export default class ActorArtichron extends Actor {
    */
   calculateDamage(values, {numeric = true} = {}) {
     if (foundry.utils.getType(values) === "number") {
-      values = {none: values};
+      values = {none: {value: values}};
     }
 
     values = foundry.utils.deepClone(values);
@@ -253,6 +253,9 @@ export default class ActorArtichron extends Actor {
     if (damaged) {
       if (attributes.has("rending")) await this.applyCondition("bleeding");
       if (attributes.has("bludgeoning")) await this.applyCondition("hindered");
+      if (!this.system.health.value) await this.toggleStatusEffect(CONFIG.specialStatusEffects.DEFEATED, {
+        active: true, overlay: true
+      });
     }
 
     return this;
@@ -269,6 +272,7 @@ export default class ActorArtichron extends Actor {
     const hp = foundry.utils.deepClone(this.system.health);
     const v = Math.clamp(hp.value + Math.abs(value), 0, hp.max);
     await this.update({"system.health.value": v}, {diff: false});
+    if (this.system.health.value) await this.toggleStatusEffect(CONFIG.specialStatusEffects.DEFEATED, {active: false});
     return this;
   }
 


### PR DESCRIPTION
Closes #71.

`Actor#applyDamage` now applies the Defeated condition if the damage put them at 0 health.
`Actor#applyHealing` now removes the Defeated condition if the healing raised them above 0 health.

Also fixed a bug where `applyDamage` didn't properly instantiate an object when given a numeric value.