### PR TITLE
[#63, #69, #72] Various tooltip fixes

### DIFF
--- a/module/documents/item/item-arsenal-shield.mjs
+++ b/module/documents/item/item-arsenal-shield.mjs
@@ -122,7 +122,7 @@ export default class ShieldData extends ArsenalData {
 
   /** @override */
   _prepareTooltipProperties() {
-    const props = [];
+    const props = super._prepareTooltipProperties();
     props.push({title: "Armor", label: this.armor.value ?? 0, icon: "fa-solid fa-shield"});
     return props;
   }

--- a/module/documents/item/item-elixir.mjs
+++ b/module/documents/item/item-elixir.mjs
@@ -297,6 +297,7 @@ export default class ElixirData extends ItemSystemModel {
   _prepareTooltipProperties() {
     const props = super._prepareTooltipProperties();
     props.push({title: "Uses", label: `${this.usage.value}/${this.usage.max}`, icon: "fa-solid fa-flask"});
+    props.push({title: "AP", label: String(1), icon: "fa-solid fa-circle"});
     return props;
   }
 }

--- a/module/documents/item/system-model.mjs
+++ b/module/documents/item/system-model.mjs
@@ -155,6 +155,7 @@ export default class ItemSystemModel extends foundry.abstract.TypeDataModel {
       tags: this._prepareTooltipTags(),
       properties: this._prepareTooltipProperties()
     };
+    context.propsCol = Math.min(4, context.properties.length);
 
     return context;
   }
@@ -197,12 +198,14 @@ export default class ItemSystemModel extends foundry.abstract.TypeDataModel {
     props.push({title: "Weight", label: this.weight.total, icon: "fa-solid fa-weight-hanging"});
 
     if (this.schema.has("quantity")) {
-      props.push({title: "Quantity", label: this.quantity.value ?? 0, icon: "fa-solid fa-cubes-stacked"});
+      props.push({title: "Qty", label: this.quantity.value ?? 0, icon: "fa-solid fa-cubes-stacked"});
     }
 
     if (this.parent.isArsenal) {
       if (this.parent.isMelee) props.push({title: "Reach", label: `${this.range.reach}m`, icon: "fa-solid fa-bullseye"});
       else props.push({title: "Range", label: `${this.range.value}m`, icon: "fa-solid fa-bullseye"});
+
+      props.push({title: "AP", label: this.cost.value, icon: "fa-solid fa-circle"});
     }
 
     return props;

--- a/styles/sheets-items.css
+++ b/styles/sheets-items.css
@@ -67,7 +67,7 @@
   background-color: rgb(18, 10, 61);
   --tooltip-gray: rgb(177, 177, 177);
 
-  .weapon, .shield, .armor, .elixir, .part, .spell {
+  .weapon, .shield, .armor, .elixir, .part, .spell, .ammo {
     display: flex;
     flex-direction: column;
     width: 300px;
@@ -132,6 +132,7 @@
         overflow: hidden auto;
         min-height: 100px;
         max-height: 200px;
+        color: white;
       }
     }
 

--- a/templates/item/tooltip.hbs
+++ b/templates/item/tooltip.hbs
@@ -75,7 +75,7 @@
   {{/if}}
 
   {{#if properties.length}}
-  <div class="properties" style="--length: {{properties.length}};">
+  <div class="properties" style="--length: {{propsCol}};">
     {{#each properties}}
     <div class="property">
       <div class="title">{{title}}</div>


### PR DESCRIPTION
Closes #63.
Closes #69.
Closes #72.

Also fixes a bug where shields only displayed one property.

![image](https://github.com/user-attachments/assets/18985d99-09af-4cd0-bdd3-32fdd5af368c)
