### PR TITLE
[#60] Fusion Tab on item sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -630,6 +630,8 @@
 
 "ItemFusionDialog": {
   "Changes": "Changes",
+  "Default": "Default",
+  "DefaultFusion": "Fusion: {name}",
   "Fuse": "Fuse",
   "FusionLabel": "Fusion",
   "Split": "Split",

--- a/lang/en.json
+++ b/lang/en.json
@@ -575,6 +575,7 @@
   "Ammunition": "Ammunition",
   "Blocking": "Blocking",
   "Bludgeoning": "Bludgeoning",
+  "Fusion": "Fusion",
   "Magical": "Magical",
   "Parrying": "Parrying",
   "Rending": "Rending"

--- a/lang/en.json
+++ b/lang/en.json
@@ -101,6 +101,7 @@
   "Effects": "Effects",
   "Equipment": "Equipment",
   "Favorites": "Favorites",
+  "Fusion": "Fusion",
   "Gear": "Gear",
   "Inventory": "Inventory",
   "Items": "Items",

--- a/module/applications/base-sheet.mjs
+++ b/module/applications/base-sheet.mjs
@@ -120,8 +120,8 @@ export const ArtichronSheetMixin = Base => {
         acc[v.id] = {
           ...v,
           active: isActive,
-          cssClass: isActive ? "active" : "",
-          tabCssClass: isActive ? "tab scrollable active" : "tab scrollable"
+          cssClass: [isActive ? "active" : null].filterJoin(" "),
+          tabCssClass: ["tab", "scrollable", isActive ? "active" : null].filterJoin(" ")
         };
         return acc;
       }, {});

--- a/module/applications/item/fusion-dialog.mjs
+++ b/module/applications/item/fusion-dialog.mjs
@@ -64,7 +64,7 @@ export default class ItemFusionDialog extends HandlebarsApplicationMixin(Applica
    * Track the selected fusion.
    * @type {string}
    */
-  #selectedFusion = null;
+  #selectedFusion = "default";
 
   /* -------------------------------------------------- */
 
@@ -120,14 +120,17 @@ export default class ItemFusionDialog extends HandlebarsApplicationMixin(Applica
       };
 
       // Fusion.
-      const eChoices = {};
+      const eChoices = {
+        default: "ARTICHRON.ItemFusionDialog.Default"
+      };
       for (const effect of this.#item.effects) {
         if (effect.isTransferrableFusion) eChoices[effect.id] = effect.name;
       }
       context.fusion = {
         field: new StringField({
           choices: eChoices,
-          label: "ARTICHRON.ItemFusionDialog.FusionLabel"
+          label: "ARTICHRON.ItemFusionDialog.FusionLabel",
+          required: true
         }),
         dataset: {change: "fusion"}
       };
@@ -137,7 +140,11 @@ export default class ItemFusionDialog extends HandlebarsApplicationMixin(Applica
       context.sourceImage = this.#item.img;
       context.targetDisabled = !target;
     } else if (partId === "changes") {
-      const effect = this.#item.effects.get(this.#selectedFusion);
+      const effect = this.#item.effects.get(this.#selectedFusion) ?? new ActiveEffect.implementation({
+        type: "fusion",
+        name: game.i18n.format("ARTICHRON.ItemFusionDialog.DefaultFusion", {name: this.#item.name}),
+        img: this.#item.img
+      }, {parent: this.#item});
       const target = this.#item.actor.items.get(this.#selectedTarget);
       const changes = (target && effect) ? target.system.createFusionTranslation(effect) : [];
       context.changes = [];
@@ -159,7 +166,8 @@ export default class ItemFusionDialog extends HandlebarsApplicationMixin(Applica
       }
     } else if (partId === "footer") {
       context.footer = {
-        disabled: !this.#item.actor.items.get(this.#selectedTarget) || !this.#item.effects.get(this.#selectedFusion),
+        disabled: !this.#item.actor.items.get(this.#selectedTarget)
+        || ((this.#selectedFusion !== "default") && !this.#item.effects.get(this.#selectedFusion)),
         label: "ARTICHRON.ItemFusionDialog.Fuse"
       };
     }

--- a/module/applications/item/item-sheet-base.mjs
+++ b/module/applications/item/item-sheet-base.mjs
@@ -25,6 +25,7 @@ export default class ItemSheetArtichron extends ArtichronSheetMixin(foundry.appl
     description: {template: "systems/artichron/templates/item/item-description.hbs", scrollable: [""]},
     details: {template: "systems/artichron/templates/item/item-details.hbs", scrollable: [""]},
     secondary: {template: "systems/artichron/templates/item/item-secondary.hbs", scrollable: [""]},
+    fusion: {template: "systems/artichron/templates/item/item-fusion.hbs", scrollable: [""]},
     effects: {template: "systems/artichron/templates/shared/effects.hbs", scrollable: [""]}
   };
 
@@ -35,6 +36,7 @@ export default class ItemSheetArtichron extends ArtichronSheetMixin(foundry.appl
     description: {id: "description", group: "primary", label: "ARTICHRON.SheetTab.Description"},
     details: {id: "details", group: "primary", label: "ARTICHRON.SheetTab.Details"},
     secondary: {id: "secondary", group: "primary", label: "ARTICHRON.SheetTab.Properties"},
+    fusion: {id: "fusion", group: "primary", label: "ARTICHRON.SheetTab.Fusion"},
     effects: {id: "effects", group: "primary", label: "ARTICHRON.SheetTab.Effects"}
   };
 

--- a/module/documents/item/item.mjs
+++ b/module/documents/item/item.mjs
@@ -86,7 +86,7 @@ export default class ItemArtichron extends Item {
   /* -------------------------------------------------- */
 
   /**
-   * Does this item have any valid fusions it can apply?
+   * Can this item be fused onto another?
    * @type {boolean}
    */
   get hasFusions() {

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -436,6 +436,11 @@ SYSTEM.ITEM_ATTRIBUTES = {
     types: new Set(["weapon"]),
     transferrable: true
   },
+  fusion: {
+    label: "ARTICHRON.ItemAttribute.Fusion",
+    types: new Set(["weapon", "shield", "spell", "armor"]),
+    transferrable: false
+  },
   magical: {
     label: "ARTICHRON.ItemAttribute.Magical",
     transferrable: true

--- a/templates/item/item-fusion.hbs
+++ b/templates/item/item-fusion.hbs
@@ -1,0 +1,42 @@
+<div class="{{tabs.fusion.tabCssClass}}" data-group="primary" data-tab="fusion">
+  {{#unless canFuse}}
+  <fieldset>
+    <legend>Fusion</legend>
+    <p class="hint" style="font-style: italic;">This item type is not valid for fusions.</p>
+  </fieldset>
+  {{else}}
+  <div class="effects-list">
+    {{#if activeFusions.length}}
+    <header>
+      <span class="label">{{localize "ARTICHRON.Effect.ActiveFusions"}}</span>
+      <span class="source">{{localize "ARTICHRON.Effect.Source"}}</span>
+      <span class="controls" style="margin-left: 2px;"></span>
+    </header>
+
+    {{#each activeFusions}}
+    {{effectEntry effect enriched=enrichedText}}
+    {{/each}}
+
+    {{/if}}
+
+    {{#if document.hasFusions}}
+    <header>
+      <span class="label">{{localize "ARTICHRON.Effect.FusionOptions"}}</span>
+      <span class="source"></span>
+      {{#if @root.isEditMode}}
+      <button class="controls" type="button" data-action="createEffect" data-tooltip="ARTICHRON.SheetActions.CreateFusion" data-type="fusion">
+        <i class="fa-solid fa-plus"></i>
+      </button>
+      {{else}}
+      <span class="controls" style="margin-left: 2px;"></span>
+      {{/if}}
+    </header>
+
+    {{#each fusions}}
+    {{effectEntry effect enriched=enrichedText}}
+    {{/each}}
+    {{/if}}
+
+  </div>
+  {{/unless}}
+</div>

--- a/templates/shared/effects.hbs
+++ b/templates/shared/effects.hbs
@@ -13,20 +13,6 @@
     {{/each}}
     {{/if}}
 
-    {{#if (and canFuse activeFusions.length)}}
-
-    <header>
-      <span class="label">{{localize "ARTICHRON.Effect.ActiveFusions"}}</span>
-      <span class="source">{{localize "ARTICHRON.Effect.Source"}}</span>
-      <span class="controls" style="margin-left: 2px;"></span>
-    </header>
-
-    {{#each activeFusions}}
-    {{effectEntry effect enriched=enrichedText}}
-    {{/each}}
-
-    {{/if}}
-
     {{#if isItem}}
 
     <header>
@@ -61,25 +47,6 @@
     {{#each effects}}
     {{effectEntry effect enriched=enrichedText}}
     {{/each}}
-
-    {{#if canFuse}}
-    <header>
-      <span class="label">{{localize "ARTICHRON.Effect.FusionOptions"}}</span>
-      <span class="source"></span>
-      {{#if @root.isEditMode}}
-      <button class="controls" type="button" data-action="createEffect" data-tooltip="ARTICHRON.SheetActions.CreateFusion" data-type="fusion">
-        <i class="fa-solid fa-plus"></i>
-      </button>
-      {{else}}
-      <span class="controls" style="margin-left: 2px;"></span>
-      {{/if}}
-    </header>
-
-    {{#each fusions}}
-    {{effectEntry effect enriched=enrichedText}}
-    {{/each}}
-    {{/if}}
-
   </div>
 
 </div>


### PR DESCRIPTION
Closes #60.

- Moves active fusions and fusion options into their own tab on the item sheet.
- For now, the tab is always visible but displays a hint for invalid item types (all types other than arsenal and armor).
- If the arsenal or armor item has the 'Fusion' attribute, they can create a fusion option on this new tab.
- If they don't have that attribute, this tab only displays any active fusions.
- A fusion option is no longer required; if omitted, a default "dummy" effect is used which has no additional changes.

Follow-up work: Split item sheets from "Base" into one per item type for better configuration.